### PR TITLE
1.65 Generation

### DIFF
--- a/src/generator/Generator.ts
+++ b/src/generator/Generator.ts
@@ -74,6 +74,7 @@ export default class Generator {
 
     private createDefinitions(apiList: UI5API[], version: string): void {
         let allSymbols = apiList.map((api) => api.symbols).reduce((a, b) => a.concat(b));
+        allSymbols = allSymbols.filter((symbol) => !this.config.ignore.ignoreSymbolKinds.has(symbol.kind));
         let rootNodes = TreeBuilder.createFromSymbolsArray(this.config, allSymbols) as TreeNode[];
         let baseDefinitionsPath = this.config.output.definitionsPath.replace(versionMarker, version);
         let indexContent: string[] = [];

--- a/src/generator/GeneratorConfig.ts
+++ b/src/generator/GeneratorConfig.ts
@@ -31,6 +31,7 @@ export default interface Config {
         ignoreNamespaces: Set<string>,
         ignoreMethods: Set<string>,
         ignoreStaticMethods: Set<string>,
+        ignoreSymbolKinds: Set<string>,
         ignoreStaticProperties: Set<string>,
         smartStaticMethodFixing: Set<string>,
         smartStaticMethodFixingAllowedMethods: Set<string>,

--- a/src/generator/config.json5
+++ b/src/generator/config.json5
@@ -20,22 +20,25 @@
         "jsonLocation": "designtime/api.json",
         "versions": [
             // "1.38.33", // fails on sap/f
-            "1.44.28",
+            // "1.44.28",
             // "1.48.19",
             // "1.50.9",
-            "1.52.8",
+            // "1.52.8",
             // "1.54.2"
+            "1.65.1"
         ],
         "namespaces": [
             "sap/ui/core",
             "sap/ui/unified",
             "sap/ui/commons",
-            "sap/ui/demokit",
-            // "sap/ui/dt",
+            // "sap/ui/demokit",
+            "sap/ui/dt",
             "sap/ui/layout",
             "sap/ui/suite",
             "sap/ui/table",
             "sap/ui/ux3",
+            "sap/ui/fl",
+            "sap/ui/codeeditor",
             "sap/m",
             "sap/f",
             "sap/tnt",
@@ -91,6 +94,10 @@
             "sap.m.NotificationListBase.setDatetime",
             "sap.m.NotificationListItem.setDatetime",
         ],
+
+        "ignoreSymbolKinds": [
+            "function"
+        ]
 
     },
 

--- a/src/generator/util/ApiFetcher.ts
+++ b/src/generator/util/ApiFetcher.ts
@@ -19,7 +19,7 @@ export async function getApiJson(config: Config, namespace: string, version: str
             console.log(`Making local file '${path}'`);
             let api = await getServerApiJson(config, namespace, version);
             fse.ensureFileSync(path);
-            fse.writeJson(path, api, {
+            fse.writeJsonSync(path, api, {
                 spaces: config.output.indentation,
             });
             return api;


### PR DESCRIPTION
Hey Ryan

I've fixed a bug where theres a race condition when writing out the api.json file. I also added a new feature to ignore certain symbol types. An addition of UI5 1.65 comes with function symbol types and I'm unsure on how to handle it. I've added a feature to just skip certain symbol kinds. 

This PR can build 1.65's type script definition. I'm not familiar with the uses of nodeTypes in the tree builder so i don't know what the ramifications are of me skipping the function symbols. 

Thanks!
Leon